### PR TITLE
Add shadcn UI integration

### DIFF
--- a/graph-tutorial/package.json
+++ b/graph-tutorial/package.json
@@ -16,7 +16,12 @@
     "react-router-dom": "^6.26.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^3.5.2",
-    "windows-iana": "^5.1.0"
+    "windows-iana": "^5.1.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.292.0",
+    "tailwind-merge": "^1.14.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -53,7 +58,10 @@
     "@types/react": "^18.3.6",
     "@types/react-dom": "^18.3.0",
     "@types/react-router-dom": "^5.3.3",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.23",
+    "autoprefixer": "^10.4.14"
   },
   "jest": {
     "transformIgnorePatterns": [],

--- a/graph-tutorial/postcss.config.js
+++ b/graph-tutorial/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/graph-tutorial/src/Welcome.tsx
+++ b/graph-tutorial/src/Welcome.tsx
@@ -3,9 +3,10 @@
 
 // <WelcomeSnippet>
 import {
-  Button,
+  Button as BsButton,
   Container
 } from 'react-bootstrap';
+import { Button } from './components/ui/button';
 import { AuthenticatedTemplate, UnauthenticatedTemplate } from '@azure/msal-react';
 import { useAppContext } from './AppContext';
 
@@ -26,7 +27,8 @@ export default function Welcome() {
           </div>
         </AuthenticatedTemplate>
         <UnauthenticatedTemplate>
-          <Button color="primary" onClick={app.signIn!}>Click here to sign in</Button>
+          <BsButton color="primary" onClick={app.signIn!} className="me-2">Click here to sign in</BsButton>
+          <Button onClick={app.signIn!}>Sign in with Shadcn</Button>
         </UnauthenticatedTemplate>
       </Container>
     </div>

--- a/graph-tutorial/src/components/ui/button.tsx
+++ b/graph-tutorial/src/components/ui/button.tsx
@@ -1,0 +1,43 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '../../lib/utils'
+import * as React from 'react'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-600 text-white hover:bg-blue-700',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/graph-tutorial/src/index.css
+++ b/graph-tutorial/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
   padding-top: 4.5rem;
 }

--- a/graph-tutorial/src/lib/utils.ts
+++ b/graph-tutorial/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/graph-tutorial/tailwind.config.js
+++ b/graph-tutorial/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [require("tailwindcss-animate")],
+};


### PR DESCRIPTION
## Summary
- add shadcn dependencies to package.json
- set up Tailwind via config files
- expose helper `cn` and a `Button` component
- demonstrate using shadcn Button alongside Bootstrap

## Testing
- `yarn test --watchAll=false` *(fails: package missing from lockfile)*